### PR TITLE
Update OSM for solc 0.6.X compatibility

### DIFF
--- a/src/osm.sol
+++ b/src/osm.sol
@@ -33,14 +33,14 @@ contract LibNote {
         assembly {
             // log an 'anonymous' event with a constant 6 words of calldata
             // and four indexed topics: selector, caller, arg1 and arg2
-            let mark := msize                         // end of memory ensures zero
+            let mark := msize()                       // end of memory ensures zero
             mstore(0x40, add(mark, 288))              // update free memory pointer
             mstore(mark, 0x20)                        // bytes type data offset
             mstore(add(mark, 0x20), 224)              // bytes size (padded)
             calldatacopy(add(mark, 0x40), 0, 224)     // bytes payload
             log4(mark, 288,                           // calldata
                  shl(224, shr(224, calldataload(0))), // msg.sig
-                 caller,                              // msg.sender
+                 caller(),                            // msg.sender
                  calldataload(4),                     // arg1
                  calldataload(36)                     // arg2
                 )

--- a/src/osm.t.sol
+++ b/src/osm.t.sol
@@ -4,8 +4,8 @@ import "ds-test/test.sol";
 import {DSValue} from "ds-value/value.sol";
 import {OSM} from "./osm.sol";
 
-contract Hevm {
-    function warp(uint256) public;
+interface Hevm {
+    function warp(uint256) external;
 }
 
 contract OSMTest is DSTest {


### PR DESCRIPTION
Updates to make OSM compatible with solc 0.5.X and 0.6.X