### PR TITLE
Update makefile to use solc 0.5.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all    :; dapp build
+all    :; dapp --use solc:0.5.12 build
 clean  :; dapp clean
-test   :; dapp test
-deploy :; dapp create OSM
+test   :; dapp --use solc:0.5.12 test
+deploy :; dapp --use solc:0.5.12 create OSM

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all    :; dapp --use solc:0.5.12 build
 clean  :; dapp clean
 test   :; dapp --use solc:0.5.12 test
-deploy :; dapp --use solc:0.5.12 create OSM
+deploy :; dapp --use solc:0.5.12 build && dapp create OSM


### PR DESCRIPTION
Updates the make commands to specify 0.5.12 instead of the latest dapp solc.